### PR TITLE
docs: Fix a few typos

### DIFF
--- a/demo/import/docopt.py
+++ b/demo/import/docopt.py
@@ -512,7 +512,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
         If passed, the object will be printed if --version is in
         `argv`.
     options_first : bool (default: False)
-        Set to True to require options preceed positional arguments,
+        Set to True to require options precede positional arguments,
         i.e. to forbid options and positional arguments intermix.
 
     Returns

--- a/demo/import/paypal/response.py
+++ b/demo/import/paypal/response.py
@@ -11,7 +11,7 @@ import paypal.exceptions
 
 class PayPalResponse(object):
     """
-    Parse and prepare the reponse from PayPal's API. Acts as somewhat of a
+    Parse and prepare the response from PayPal's API. Acts as somewhat of a
     glorified dictionary for API responses.
     
     NOTE: Don't access self.raw directly. Just do something like

--- a/docs/concerns/builtin/overflow_len.md
+++ b/docs/concerns/builtin/overflow_len.md
@@ -102,9 +102,9 @@ KO: 'class C' with 'return 2L'
 Error: TypeError('__len__() should return an int',)
 ```
 
-in this case the ```len()``` function in python does not check for the legth of the object and does not use "python int objects" (unlimited) and this can cause an ```Overflow``` error as the object may contain the actual `.length` property.
+in this case the ```len()``` function in python does not check for the length of the object and does not use "python int objects" (unlimited) and this can cause an ```Overflow``` error as the object may contain the actual `.length` property.
 
-The reason of this is beacuse ```len(obj)``` is implemented using PyObject_Size(), which in turn it stores the result into a Py_ssize_t, and this object is limited to sys.maxsize (```2**31-1``` for 32bit or ```2**63-1``` for 64bit systems).
+The reason of this is because ```len(obj)``` is implemented using PyObject_Size(), which in turn it stores the result into a Py_ssize_t, and this object is limited to sys.maxsize (```2**31-1``` for 32bit or ```2**63-1``` for 64bit systems).
 
 And when the length of the object is bigger then the maximum size of an **integer** object in python, the type of the object changes to **long**.
 

--- a/docs/concerns/io/overflow_file_date.md
+++ b/docs/concerns/io/overflow_file_date.md
@@ -25,7 +25,7 @@ testfile = 'TESTFILE'
 stinfo = os.stat('TESTFILE')
 print(stinfo)
 
-# Using os.stat to recieve atime and mtime of file
+# Using os.stat to receive atime and mtime of file
 print("access time of TESTFILE: %s" %stinfo.st_atime)
 print("modified time of TESTFILE: %s" %stinfo.st_mtime)
 
@@ -39,7 +39,7 @@ os.utime("TESTFILE",(-2147483648, 2147483648))
 stinfo = os.stat('TESTFILE')
 print(stinfo)
 
-# Using os.stat to recieve atime and mtime of file
+# Using os.stat to receive atime and mtime of file
 print("access time of TESTFILE: %s" %stinfo.st_atime)
 print("modified time of TESTFILE: %s" %stinfo.st_mtime)
 
@@ -49,7 +49,7 @@ os.utime("TESTFILE",(1330712280, 1330712292))
 stinfo = os.stat('TESTFILE')
 print(stinfo)
 
-# Using os.stat to recieve atime and mtime of file
+# Using os.stat to receive atime and mtime of file
 print("access time of TESTFILE: %s" %stinfo.st_atime)
 print("modified time of TESTFILE: %s" %stinfo.st_mtime)
 

--- a/pysec/io/fd.py
+++ b/pysec/io/fd.py
@@ -283,7 +283,7 @@ class File(FD):
     @check.delimit('fd-reg-open')
     def open(fpath, oflags, mode=0666):
         """Open a file descript for a regular file in fpath using the open mode
-        specifie by *oflag* with *mode*"""
+        specified by *oflag* with *mode*"""
         _oflags = FOFLAGS2OFLAGS.get(int(oflags), None)
         if oflags is None:
             raise ValueError("unknown file open mode: %r" % oflags)
@@ -526,7 +526,7 @@ class Directory(FD):
 
     def fileat(self, fpath, oflags, mode=0644):
         """Open a file descript for a regular file in fpath using the open mode
-        specifie by *oflag* with *mode*"""
+        specified by *oflag* with *mode*"""
         _oflags = FOFLAGS2OFLAGS.get(int(oflags), None)
         if oflags is None:
             raise ValueError("unknown file open mode: %r" % oflags)

--- a/pysec/utils.py
+++ b/pysec/utils.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 # -*- coding: ascii -*-
-"""A lot of utilies for:
+"""A lot of utilities for:
     - Operations on paths
     - Counting
 """

--- a/tools/pescan/docopt.py
+++ b/tools/pescan/docopt.py
@@ -512,7 +512,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
         If passed, the object will be printed if --version is in
         `argv`.
     options_first : bool (default: False)
-        Set to True to require options preceed positional arguments,
+        Set to True to require options precede positional arguments,
         i.e. to forbid options and positional arguments intermix.
 
     Returns


### PR DESCRIPTION
There are small typos in:
- demo/import/docopt.py
- demo/import/paypal/response.py
- docs/concerns/builtin/overflow_len.md
- docs/concerns/io/overflow_file_date.md
- pysec/io/fd.py
- pysec/utils.py
- tools/pescan/docopt.py

Fixes:
- Should read `specified` rather than `specifie`.
- Should read `precede` rather than `preceed`.
- Should read `utilities` rather than `utilies`.
- Should read `response` rather than `reponse`.
- Should read `receive` rather than `recieve`.
- Should read `length` rather than `legth`.
- Should read `because` rather than `beacuse`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md